### PR TITLE
Fixed _1 p: y for prime arguments.

### DIFF
--- a/primitives.cs
+++ b/primitives.cs
@@ -878,7 +878,7 @@ namespace MicroJ {
             Func<long, long[]> fls = null;
             long[] frame = null;
             if (a == null) fl = Primes.GetNthPrime;
-            else if (xv == -1) fl = (l) => Primes.Pi((float)l);
+            else if (xv == -1) fl = (l) => Primes.Pi((float)(l-0.5f));
             else if (xv == 0) fb = (l) => !Primes.IsPrime(l);
             else if (xv == 1) fb = Primes.IsPrime;
             else if (xv == 2) {
@@ -2199,14 +2199,20 @@ namespace MicroJ {
         }
 
         public static long Pi(float n) {
-            if (n <= 1)
+            if (n < 2)
                 return 0;
             if (n < 3)
                 return 1;
+            if (n < 5)
+                return 2;
+            if (n < 7)
+                return 3;
+            if (n < 11)
+                return 4;
             long c = Pi((float)Math.Pow(n, 1.0f / 3));
 
             long mu = Pi((float)Math.Sqrt(n)) - c;
-            return (long)(phi(n, c) + c * (mu + 1) + (mu * mu - mu) * 0.5f - 1 - SumPi(n, c, mu));
+            return (phi(n, c) + (long)(c * (mu + 1) + (mu * mu - mu) * 0.5f) - 1 - SumPi(n, c, mu));
         }
 
         private static long SumPi(float m, long n, long mu) {

--- a/tests.ijs
+++ b/tests.ijs
@@ -98,7 +98,7 @@ NB. 0 conjunction
 NB. explicit verb
 NB. 'abc' -: (3 : '1+1') ''
 (_1 p: 10 20 50 100) -: 4 8 15 25                    NB. Primes less than
-NB. Not working  (_1 p: 17 37 79 101) -: 6 11 21 25  NB. Primes less than (prime arguments)
+(_1 p: 17 37 79 101) -: 6 11 21 25  NB. Primes less than (prime arguments)
 
 (0 p: i. 5) -: 1 1 0 0 1                             NB. is not prime
 (1 p: 2 3 17 79 199 3581) -: 1 1 1 1 1 1             NB. is prime (true)


### PR DESCRIPTION
Before, it counted primes less than or equal to, now it just calculates less than.
e.g. before, _1 p: 101 gave 26
now it gives 25.
